### PR TITLE
issue: #29: added multi part upload feature for large objects

### DIFF
--- a/src/main/java/com/jcabi/s3/Ocket.java
+++ b/src/main/java/com/jcabi/s3/Ocket.java
@@ -110,7 +110,8 @@ public interface Ocket extends Comparable<Ocket> {
     /**
      * Write new content to the object.
      * @param input Where to get content
-     * @param meta Metadata to save
+     * @param meta Metadata to save. Should contains input length for large
+     * object, it will make multi part upload possible.
      * @throws IOException If fails
      */
     void write(

--- a/src/main/java/com/jcabi/s3/Ocket.java
+++ b/src/main/java/com/jcabi/s3/Ocket.java
@@ -111,7 +111,7 @@ public interface Ocket extends Comparable<Ocket> {
      * Write new content to the object.
      * @param input Where to get content
      * @param meta Metadata to save. Should contains input length for large
-     * object, it will make multi part upload possible.
+     *  object, it will make multi part upload possible.
      * @throws IOException If fails
      */
     void write(

--- a/src/main/java/com/jcabi/s3/Ocket.java
+++ b/src/main/java/com/jcabi/s3/Ocket.java
@@ -111,7 +111,7 @@ public interface Ocket extends Comparable<Ocket> {
      * Write new content to the object.
      * @param input Where to get content
      * @param meta Metadata to save. Should contains input length for large
-     *  object, it will make multi part upload possible.
+     *  object, otherwise multi-part uploads won't be possible.
      * @throws IOException If fails
      */
     void write(


### PR DESCRIPTION
Right now jcabi-s3 doesn't have multi part upload feature. 
It prohibits uploading of large files, as they have to be buffered in memory (to calculate file size) before being uploaded to S3.
According to this discussion under https://github.com/Nerodesk/nerodesk/issues/253, was merged changes to enable get size of file that downloading.   So now it is possible provide size of object with input stream to it. 

Fix contains update of "write" method. Now TransferManager from AWS SDK used to enable multi part upload if input stream contains huge object. Also description updated in interface

Behaving should be the same.  


