### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-s3/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-s3)
 [![Dependencies](https://www.versioneye.com/user/projects/561aa1eca193340f32000fd3/badge.svg?style=flat)](https://www.versioneye.com/user/projects/561aa1eca193340f32000fd3)
 [![Coverage Status](https://coveralls.io/repos/jcabi/jcabi-s3/badge.svg?branch=master&service=github)](https://coveralls.io/github/jcabi/jcabi-s3?branch=master)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/AmazonS3?utm_source=AmazonS3Github&utm_medium=button&utm_content=Vender_GitHub)
 
 More details are here: [s3.jcabi.com](http://s3.jcabi.com/index.html).
 Also, read this blog post: [Object-Oriented Java Adapter of Amazon S3 SDK](http://www.yegor256.com/2014/05/26/amazon-s3-java-oop-adapter.html).


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out AmazonS3 API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!